### PR TITLE
feat: email sending service (#14)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation "org.springframework.boot:spring-boot-starter-validation"
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	compileOnly 'org.projectlombok:lombok'
 	compileOnly 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly "org.postgresql:postgresql"

--- a/src/main/java/coLaon/ClaonBack/common/email/controller/SendEmailController.java
+++ b/src/main/java/coLaon/ClaonBack/common/email/controller/SendEmailController.java
@@ -1,0 +1,29 @@
+package coLaon.ClaonBack.common.email.controller;
+
+import java.util.List;
+
+import coLaon.ClaonBack.common.email.dto.SendEmailRequestDto;
+import coLaon.ClaonBack.common.email.service.SendEmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/email")
+public class SendEmailController {
+    private final SendEmailService sendEmailService;
+
+    @PostMapping("/send")
+    public void sendEmail(@RequestBody @Valid SendEmailRequestDto sendEmailRequestDto) {
+        List<String> cc = sendEmailRequestDto.getCcAddresses();
+        List<String> bcc = sendEmailRequestDto.getBccAddresses();
+        
+        sendEmailService.sendEmail(sendEmailRequestDto.getSubject(),
+                                   sendEmailRequestDto.getBody(),
+                                   sendEmailRequestDto.isHtmlBody(),
+                                   sendEmailRequestDto.getToAddresses().toArray(new String[0]),
+                                   (cc != null ? cc.toArray(new String[0]) : null),
+                                   (bcc != null ? bcc.toArray(new String[0]) : null));
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/common/email/dto/SendEmailRequestDto.java
+++ b/src/main/java/coLaon/ClaonBack/common/email/dto/SendEmailRequestDto.java
@@ -1,0 +1,27 @@
+package coLaon.ClaonBack.common.email.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SendEmailRequestDto {
+    
+    @NotNull
+    private String subject;
+    
+    @NotNull
+    private String body;
+    private boolean htmlBody;
+    
+    @NotNull
+    private List<String> toAddresses;
+    private List<String> ccAddresses;
+    private List<String> bccAddresses;
+    
+}

--- a/src/main/java/coLaon/ClaonBack/common/email/service/SendEmailService.java
+++ b/src/main/java/coLaon/ClaonBack/common/email/service/SendEmailService.java
@@ -1,0 +1,192 @@
+package coLaon.ClaonBack.common.email.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import org.springframework.mail.javamail.JavaMailSender;
+
+import javax.mail.internet.MimeMessage;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
+import com.sun.mail.smtp.SMTPAddressFailedException;
+import org.springframework.core.NestedExceptionUtils;
+
+import org.springframework.mail.javamail.MimeMessageHelper;
+import javax.mail.MessagingException;
+import org.springframework.web.util.HtmlUtils;
+
+import coLaon.ClaonBack.common.exception.BadRequestException;
+import coLaon.ClaonBack.common.exception.UnavailableMailServerException;
+import coLaon.ClaonBack.common.exception.InternalServerErrorException;
+import coLaon.ClaonBack.common.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class SendEmailService {
+    private final JavaMailSender emailSender;
+    
+    private static final String FROM_ADDRESS = "CLAON <help.claon@gmail.com>";
+    private static final String HEADER_LOGO_IMG_URL = "";
+    private static final String HEADER_TITLE = "CLAON";
+    private static final String WRAPPER_BGCOLOR_RGB = "15,31,127"; // "r,g,b" (0-255 for each r/g/b)
+
+
+    public void sendEmail(String subject, String body, String toAddress) {
+        sendEmail(subject, body, false, new String[] { toAddress }, null, null);
+    }
+    
+    public void sendEmail(String subject, String body, String[] toAddresses) {
+        sendEmail(subject, body, false, toAddresses, null, null);
+    }
+
+    public void sendEmail(String subject, String body, boolean htmlBody, String toAddress) {
+        sendEmail(subject, body, htmlBody, new String[] { toAddress }, null, null);
+    }
+    
+    public void sendEmail(String subject, String body, boolean htmlBody, String[] toAddresses) {
+        sendEmail(subject, body, htmlBody, toAddresses, null, null);
+    }
+
+    public void sendEmail(String subject, String body,
+                          String[] toAddresses, String[] ccAddresses, String[] bccAddresses) {
+        sendEmail(subject, body, false, toAddresses, ccAddresses, bccAddresses);
+    }
+
+    
+    public void sendEmail(String subject, String body, boolean htmlBody,
+                          String[] toAddresses, String[] ccAddresses, String[] bccAddresses) {
+        
+        MimeMessage msg = emailSender.createMimeMessage();
+        String wrappedBody = wrapBodyInEmailTemplate(body, htmlBody);
+
+        
+        try {
+            
+            MimeMessageHelper msgHelper = new MimeMessageHelper(msg, true, "UTF-8");
+            
+            msgHelper.setFrom(FROM_ADDRESS);
+            msgHelper.setTo(toAddresses);
+            msgHelper.setSubject(subject);
+            msgHelper.setText(wrappedBody, true);
+            if (ccAddresses != null) {
+                msgHelper.setCc(ccAddresses);
+            }
+            if (bccAddresses != null) {
+                msgHelper.setBcc(bccAddresses);
+            }
+            
+        } catch (MessagingException e) {
+            throw new BadRequestException(ErrorCode.INVALID_FORMAT, "메일 구성 중 오류가 발생했습니다.");
+        }
+
+
+        try {
+            
+            emailSender.send(msg);
+
+        } catch (MailSendException e) {
+
+            // invalid address format
+            for (Exception innerE : e.getMessageExceptions()) {
+                if (NestedExceptionUtils.getMostSpecificCause(innerE) instanceof SMTPAddressFailedException) {
+                    throw new BadRequestException(ErrorCode.INVALID_FORMAT, "잘못된 메일 주소 형식입니다.");
+                }
+            }
+
+            // others (timeout, etc.)
+            throw new UnavailableMailServerException(ErrorCode.UNAVAILABLE_MAIL_SERVER, "메일 전송 중 오류가 발생했습니다.");
+            
+        } catch (MailException e) {
+            throw new InternalServerErrorException(ErrorCode.INTERNAL_SERVER_ERROR, "메일 처리 서버 오류입니다." );
+        }
+    }
+
+    
+    private static String wrapBodyInEmailTemplate(String body, boolean htmlBody) {
+        
+        final String DOCTYPE =
+            ("<!DOCTYPE " +
+             "htmlPUBLIC " +
+             "'-//W3C//DTD XHTML 1.0 Transitional//EN' " +
+             "'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'>");
+      
+        final String EMAIL_HEADER =
+            ("<table border='0' cellpadding='0' cellspacing='0'>"
+             + ("<tr>"
+                + ("<td>"
+                   + ("<img src='" + HEADER_LOGO_IMG_URL + "' width='60' height='60' alt='( Logo )'>")
+                   + "</td>")
+                + ("<td style='width: 20px'>"
+                   + "</td>")
+                + ("<td>"
+                   + ("<h1 style='margin: 0'>"
+                      + HEADER_TITLE
+                      + "</h1>")
+                   + "</td>")
+                + "</tr>")
+             + "</table>");
+        
+        final String EMAIL_FOOTER =
+            ("<p style='margin: 0'>"
+             + "본 메일은 발신 전용으로 회신되지 않습니다."
+             + "<br>"
+             + "Copyright © CLAON. All Rights Reserved."
+             + "</p>");
+
+        final String HORIZONTAL_DIVIDER =
+            ("<tr style='height: 2px; padding: 0; background: rgb(" + WRAPPER_BGCOLOR_RGB + ")'>"
+             + ("<td>"
+                + "</td>")
+             + "</tr>");
+        
+        
+        return
+            DOCTYPE +
+            ("<html xmlns='http://www.w3.org/1999/xhtml'>"
+             + ("<body>"
+                + ("<table style='margin: auto; padding: 20px; width: 600px; border: 0'>"
+                   + ("<tbody>"
+
+
+                      // header row
+                      + ("<tr>"
+                         + ("<td style='" + ("padding: 30px; " +
+                                             "background: rgba(" + WRAPPER_BGCOLOR_RGB + ", 0.2)'>")
+                            + EMAIL_HEADER
+                            + "</td>")
+                         + "</tr>")
+                      
+                            
+                      + HORIZONTAL_DIVIDER
+
+
+                      // body row
+                      + ("<tr>"
+                         + ("<td style='padding: 50px'>"
+                            // wrap in <pre> and escape if text mode (non-html body)
+                            + (htmlBody
+                               ? body
+                               : ("<pre>" + HtmlUtils.htmlEscape(body) + "</pre>") )
+                            + "</td>")
+                         + "</tr>")
+
+                            
+                      + HORIZONTAL_DIVIDER
+
+
+                      // footer row
+                      + ("<tr>"
+                         + ("<td style='" + ("padding: 30px; " +
+                                             "background: rgba(" + WRAPPER_BGCOLOR_RGB + ", 0.2); " +
+                                             "font-size: 10px") + "'>"
+                            + EMAIL_FOOTER
+                            + "</td>")
+                         + "</tr>")
+
+                      
+                      + "</tbody>")
+                   + "</table>")
+                + "</body>")
+             + "</html>");
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/common/exception/ErrorCode.java
+++ b/src/main/java/coLaon/ClaonBack/common/exception/ErrorCode.java
@@ -12,7 +12,17 @@ public enum ErrorCode {
     /**
      *  401 Unauthorized Error
      */
-    NOT_ACCESSIBLE(40100);
+    NOT_ACCESSIBLE(40100),
+    /**
+     *  500 Internal Server Error
+     */
+    INTERNAL_SERVER_ERROR(50000),
+    /**
+     *  503 Service Unavailable
+     */
+    UNAVAILABLE_MAIL_SERVER(50300),
+    
+    ;
 
     private final int code;
 

--- a/src/main/java/coLaon/ClaonBack/common/exception/InternalServerErrorException.java
+++ b/src/main/java/coLaon/ClaonBack/common/exception/InternalServerErrorException.java
@@ -1,0 +1,8 @@
+package coLaon.ClaonBack.common.exception;
+
+public class InternalServerErrorException extends BaseRuntimeException {
+
+    public InternalServerErrorException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/common/exception/UnavailableMailServerException.java
+++ b/src/main/java/coLaon/ClaonBack/common/exception/UnavailableMailServerException.java
@@ -1,0 +1,8 @@
+package coLaon.ClaonBack.common.exception;
+
+public class UnavailableMailServerException extends BaseRuntimeException {
+
+    public UnavailableMailServerException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/config/EmailServiceConfig.java
+++ b/src/main/java/coLaon/ClaonBack/config/EmailServiceConfig.java
@@ -1,0 +1,28 @@
+package coLaon.ClaonBack.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import java.util.Properties;
+
+@Configuration
+public class EmailServiceConfig {
+
+    @Bean
+    public JavaMailSender getJavaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+    
+        mailSender.setUsername("help.claon@gmail.com");
+        mailSender.setPassword("ianuutdoialoensu");
+    
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+    
+        return mailSender;
+    }
+}


### PR DESCRIPTION
## Related issue
- \#14

## Description
New feature - Email sending service

![mail](https://user-images.githubusercontent.com/11328091/173200056-83956403-3cb7-4b49-bbad-e99f085f1992.png)
※ This screenshots are only a prototype of the email template: details should be reviewed or changed


## Changes detail

- New config for email service (Gmail SMTP server)
- New email sending services
- New email sending controller (/api/v1/email/send)
- New email sending request dto ( { subject, body, htmlBody (bool), toAddresses, ccAddresses, bccAddresses } )
- New exceptions classes + error codes (5xx) according to the API document page in notion

### Checklist

- [ ] Test case
- [ ] End of work

