### PR TITLE
feat: email sending service (#14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ out/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+
+# CLAON secret property files
+src/main/resources/emailsender.yml

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-configuration-processor'
 	implementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	implementation 'org.mockito:mockito-junit-jupiter:4.6.1'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/coLaon/ClaonBack/common/exception/ErrorCode.java
+++ b/src/main/java/coLaon/ClaonBack/common/exception/ErrorCode.java
@@ -12,7 +12,17 @@ public enum ErrorCode {
     /**
      *  401 Unauthorized Error
      */
-    NOT_ACCESSIBLE(40100);
+    NOT_ACCESSIBLE(40100),
+    /**
+     *  500 Internal Server Error
+     */
+    INTERNAL_SERVER_ERROR(50000),
+    /**
+     *  503 Service Unavailable
+     */
+    UNAVAILABLE_MAIL_SERVER(50300),
+    
+    ;
 
     private final int code;
 

--- a/src/main/java/coLaon/ClaonBack/common/exception/InternalServerErrorException.java
+++ b/src/main/java/coLaon/ClaonBack/common/exception/InternalServerErrorException.java
@@ -1,0 +1,8 @@
+package coLaon.ClaonBack.common.exception;
+
+public class InternalServerErrorException extends BaseRuntimeException {
+
+    public InternalServerErrorException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/common/exception/UnavailableMailServerException.java
+++ b/src/main/java/coLaon/ClaonBack/common/exception/UnavailableMailServerException.java
@@ -1,0 +1,8 @@
+package coLaon.ClaonBack.common.exception;
+
+public class UnavailableMailServerException extends BaseRuntimeException {
+
+    public UnavailableMailServerException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/common/infrastructure/EmailSender.java
+++ b/src/main/java/coLaon/ClaonBack/common/infrastructure/EmailSender.java
@@ -1,0 +1,227 @@
+package coLaon.ClaonBack.common.infrastructure;
+
+import coLaon.ClaonBack.config.EmailSenderConfig;
+
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import com.sun.mail.smtp.SMTPAddressFailedException;
+import javax.mail.internet.MimeMessage;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
+
+import javax.mail.MessagingException;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.web.util.HtmlUtils;
+
+import coLaon.ClaonBack.common.exception.BadRequestException;
+import coLaon.ClaonBack.common.exception.UnavailableMailServerException;
+import coLaon.ClaonBack.common.exception.InternalServerErrorException;
+import coLaon.ClaonBack.common.exception.ErrorCode;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailSender {
+
+    private final EmailSenderConfig emailSenderConfig;
+    
+    private static JavaMailSender emailSender;
+    private static String fromAddress;
+    
+    @PostConstruct
+    private void initialize() {
+        emailSender = emailSenderConfig.getEmailSender().orElseGet(() -> {
+                log.warn("Emailsender properties do not exist!");
+                return null;
+            });
+        fromAddress = emailSenderConfig.getFromAddress();
+    }
+
+
+    public static void send(String subject, String body, String toAddress) {
+        send(subject, body, false, new String[] { toAddress }, null, null);
+    }
+    
+    public static void send(String subject, String body, String[] toAddresses) {
+        send(subject, body, false, toAddresses, null, null);
+    }
+
+    public static void send(String subject, String body, boolean isBodyHtml,
+                            String toAddress) {
+        send(subject, body, isBodyHtml, new String[] { toAddress }, null, null);
+    }
+    
+    public static void send(String subject, String body, boolean isBodyHtml,
+                            String[] toAddresses) {
+        send(subject, body, isBodyHtml, toAddresses, null, null);
+    }
+
+    public static void send(String subject, String body,
+                            String[] toAddresses, String[] ccAddresses, String[] bccAddresses) {
+        send(subject, body, false, toAddresses, ccAddresses, bccAddresses);
+    }
+
+    
+    public static void send(String subject, String body, boolean isBodyHtml,
+                            String[] toAddresses, String[] ccAddresses, String[] bccAddresses) {
+
+        if (emailSender == null) {
+            throw new InternalServerErrorException(ErrorCode.INTERNAL_SERVER_ERROR,
+                                                   "메일 설정 초기화 오류입니다.");
+        }
+
+        
+        MimeMessage msg = emailSender.createMimeMessage();
+        String wrappedBody = wrapBodyInEmailTemplate(body, isBodyHtml);
+
+        
+        try {
+            
+            MimeMessageHelper msgHelper = new MimeMessageHelper(msg, true, "UTF-8");
+
+            if (fromAddress != null) {
+                msgHelper.setFrom(fromAddress);
+            }
+            msgHelper.setTo(toAddresses);
+            msgHelper.setSubject(subject);
+            msgHelper.setText(wrappedBody, true);
+            if (ccAddresses != null) {
+                msgHelper.setCc(ccAddresses);
+            }
+            if (bccAddresses != null) {
+                msgHelper.setBcc(bccAddresses);
+            }
+            
+        } catch (MessagingException e) {
+            e.printStackTrace();
+            throw new BadRequestException(ErrorCode.INVALID_FORMAT,
+                                          "메일 구성 중 오류가 발생했습니다.");
+        }
+
+
+        try {
+            
+            emailSender.send(msg);
+
+        } catch (MailSendException e) {
+            e.printStackTrace();
+
+            // invalid address format
+            for (Exception innerE : e.getMessageExceptions()) {
+                if (NestedExceptionUtils.getMostSpecificCause(innerE)
+                    instanceof SMTPAddressFailedException) {
+                    throw new BadRequestException(ErrorCode.INVALID_FORMAT,
+                                                  "잘못된 메일 주소 형식입니다.");
+                }
+            }
+
+            // others (timeout, etc.)
+            throw new UnavailableMailServerException(ErrorCode.UNAVAILABLE_MAIL_SERVER,
+                                                     "메일 전송 중 오류가 발생했습니다.");
+            
+        } catch (MailException e) {
+            e.printStackTrace();
+            throw new InternalServerErrorException(ErrorCode.INTERNAL_SERVER_ERROR,
+                                                   "메일 처리 서버 오류입니다." );
+        }
+
+    }
+
+    
+    private static String wrapBodyInEmailTemplate(String body, boolean isBodyHtml) {
+
+        final String HEADER_LOGO_IMG_URL = "";
+        final String HEADER_TITLE = "CLAON";
+        final String WRAPPER_BGCOLOR_RGB = "15,31,127"; // "r,g,b" (0-255 for each r/g/b)
+        
+        final String DOCTYPE =
+            ("<!DOCTYPE " +
+             "htmlPUBLIC " +
+             "'-//W3C//DTD XHTML 1.0 Transitional//EN' " +
+             "'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'>");
+      
+        final String EMAIL_HEADER =
+            ("<table border='0' cellpadding='0' cellspacing='0'>"
+             + ("<tr>"
+                + ("<td>"
+                   + ("<img src='" + HEADER_LOGO_IMG_URL + "' width='60' height='60' alt='( Logo )'>")
+                   + "</td>")
+                + ("<td style='width: 20px'>"
+                   + "</td>")
+                + ("<td>"
+                   + ("<h1 style='margin: 0'>"
+                      + HEADER_TITLE
+                      + "</h1>")
+                   + "</td>")
+                + "</tr>")
+             + "</table>");
+        
+        final String EMAIL_FOOTER =
+            ("<p style='margin: 0'>"
+             + "본 메일은 발신 전용으로 회신되지 않습니다."
+             + "<br>"
+             + "Copyright © CLAON. All Rights Reserved."
+             + "</p>");
+
+        final String HORIZONTAL_DIVIDER =
+            ("<tr style='height: 2px; padding: 0; background: rgb(" + WRAPPER_BGCOLOR_RGB + ")'>"
+             + ("<td>"
+                + "</td>")
+             + "</tr>");
+        
+        
+        return
+            DOCTYPE +
+            ("<html xmlns='http://www.w3.org/1999/xhtml'>"
+             + ("<body>"
+                + ("<table style='margin: auto; padding: 20px; width: 600px; border: 0'>"
+                   + ("<tbody>"
+
+
+                      // header row
+                      + ("<tr>"
+                         + ("<td style='" + ("padding: 30px; " +
+                                             "background: rgba(" + WRAPPER_BGCOLOR_RGB + ", 0.2)'>")
+                            + EMAIL_HEADER
+                            + "</td>")
+                         + "</tr>")
+                      
+                            
+                      + HORIZONTAL_DIVIDER
+
+
+                      // body row
+                      + ("<tr>"
+                         + ("<td style='padding: 50px'>"
+                            // wrap in <pre> and escape if text mode (non-html body)
+                            + (isBodyHtml
+                               ? body
+                               : ("<pre>" + HtmlUtils.htmlEscape(body) + "</pre>") )
+                            + "</td>")
+                         + "</tr>")
+
+                            
+                      + HORIZONTAL_DIVIDER
+
+
+                      // footer row
+                      + ("<tr>"
+                         + ("<td style='" + ("padding: 30px; " +
+                                             "background: rgba(" + WRAPPER_BGCOLOR_RGB + ", 0.2); " +
+                                             "font-size: 10px") + "'>"
+                            + EMAIL_FOOTER
+                            + "</td>")
+                         + "</tr>")
+
+                      
+                      + "</tbody>")
+                   + "</table>")
+                + "</body>")
+             + "</html>");
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/config/EmailSenderConfig.java
+++ b/src/main/java/coLaon/ClaonBack/config/EmailSenderConfig.java
@@ -1,0 +1,21 @@
+package coLaon.ClaonBack.config;
+
+import java.util.Optional;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@RequiredArgsConstructor
+@ConfigurationProperties("emailsender-auth")
+public class EmailSenderConfig {
+
+    private final Optional<JavaMailSender> emailSender;
+    
+    private String fromAddress;
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,9 @@ server:
   port: 8080
 
 spring:
+  config:
+    import: "optional:classpath:emailsender.yml"
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/claon_db


### PR DESCRIPTION
## Related issue
- \#14

## Description
New feature - Email sender

※ Screenshots below are only a prototype of the email template: details should be reviewed or changed
![mail](https://user-images.githubusercontent.com/11328091/173232382-f635ae34-56d4-4304-90ff-c56132d71cc0.png)

### Prerequisites
- To make EmailSender work, you must set the following secret authentication configs in `application-emailsender-auth.yml` **WHICH IS NOT MANAGED BY GIT**:
  - **Again: this config should not be added to git!**
  - https://www.notion.so/8de752f884fa4a0ca68a3be750933b59#db3256302b4e4e27bd6d874de5a39f27

- The project will compile anyway without this config profile though. In this case, an exception occurs when sending emails but all other functions should work.

## Changes detail

- Email sender
- Properties (Gmail SMTP server configs + account secret configs)
- New exceptions classes + error codes (5xx) according to the API document page in notion 

### Checklist

- [ ] Test case
- [ ] End of work
