### PR TITLE
fix: init is deleted and is private of user when create user

### DIFF
--- a/src/main/java/coLaon/ClaonBack/user/domain/User.java
+++ b/src/main/java/coLaon/ClaonBack/user/domain/User.java
@@ -47,6 +47,8 @@ public class User extends BaseEntity {
         this.email = email;
         this.nickname = nickname;
         this.oAuthId = oAuthId;
+        this.isDeleted = false;
+        this.isPrivate = false;
     }
 
     private User(

--- a/src/test/java/coLaon/ClaonBack/service/UserServiceTest.java
+++ b/src/test/java/coLaon/ClaonBack/service/UserServiceTest.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {


### PR DESCRIPTION
## Related issue
resolves #132 

## Description
init is deleted and is private of user when create user

### Checklist

- [x] Test case
- [x] End of work
