### PR TITLE
refac: implement additional validator (constraints) for user nickname…

### DIFF
--- a/src/main/java/coLaon/ClaonBack/common/validator/UserNickname.java
+++ b/src/main/java/coLaon/ClaonBack/common/validator/UserNickname.java
@@ -1,0 +1,15 @@
+package coLaon.ClaonBack.common.validator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Constraint(validatedBy = UserNicknameValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserNickname {
+    String message() default "닉네임은 길이 2~20자의 영어, 숫자, 한글 (자모 제외) 조합이어야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/coLaon/ClaonBack/common/validator/UserNicknameValidator.java
+++ b/src/main/java/coLaon/ClaonBack/common/validator/UserNicknameValidator.java
@@ -1,0 +1,21 @@
+package coLaon.ClaonBack.common.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class UserNicknameValidator implements ConstraintValidator<UserNickname, String> {
+
+    @Override
+    public boolean isValid(String userNickname,
+                           ConstraintValidatorContext cxt) {
+
+        return (userNickname != null)
+            // length: 2-20
+            && (2 <= userNickname.length() && userNickname.length() <= 20)
+            // check if all chars are in [0-9a-zA-Z가-힣]
+            && userNickname.chars().allMatch(c -> ('0' <= c && c <= '9') // 0-9
+                                             || ('a' <= c && c <= 'z') // a-z
+                                             || ('A' <= c && c <= 'Z') // A-Z
+                                             || ('가' <= c && c <= '힣')); // (Kor)
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/user/dto/SignUpRequestDto.java
+++ b/src/main/java/coLaon/ClaonBack/user/dto/SignUpRequestDto.java
@@ -4,15 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
+import coLaon.ClaonBack.common.validator.UserNickname;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class SignUpRequestDto {
-    @NotBlank(message = "닉네임을 입력해주세요.")
-    @Size(min = 2, max = 20, message = "닉네임은 2자에서 20자 입력 가능합니다.")
+    @UserNickname
     private String nickname;
     private String metropolitanActiveArea;
     private String basicLocalActiveArea;

--- a/src/main/java/coLaon/ClaonBack/user/dto/UserModifyRequestDto.java
+++ b/src/main/java/coLaon/ClaonBack/user/dto/UserModifyRequestDto.java
@@ -5,16 +5,15 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
+import coLaon.ClaonBack.common.validator.UserNickname;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserModifyRequestDto {
-    @NotBlank
-    @Size(max=100, message="닉네임은 20자 이하여야 합니다. ")
+
+    @UserNickname
     private String nickname;
     private String metropolitanActiveArea;
     private String basicLocalActiveArea;


### PR DESCRIPTION
## Related issue
resolves #123

## Description
Please include a summary of the change and which issue is fixed.

## Changes detail

- User nickname constraint: 영숫자 또는 한글(자모제외)로 구성된 2자 이상 20자 이하 String

### Checklist

- [ ] Test case
- [x] End of work
