### PR TITLE
feat: implement user posts

### DIFF
--- a/src/main/java/coLaon/ClaonBack/center/dto/HoldInfoResponseDto.java
+++ b/src/main/java/coLaon/ClaonBack/center/dto/HoldInfoResponseDto.java
@@ -28,9 +28,4 @@ public class HoldInfoResponseDto {
                 holdInfo.getImg()
         );
     }
-
-    @Override
-    public int hashCode() {
-        return this.id.hashCode() * this.name.hashCode() * this.image.hashCode();
-    }
 }

--- a/src/main/java/coLaon/ClaonBack/common/GlobalExceptionHandler.java
+++ b/src/main/java/coLaon/ClaonBack/common/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import coLaon.ClaonBack.common.exception.MethodArgumentNotValidExceptionDto;
 import coLaon.ClaonBack.common.exception.UnauthorizedException;
 import coLaon.ClaonBack.common.exception.ConflictExceptionDto;
 import coLaon.ClaonBack.common.exception.ErrorCode;
+import coLaon.ClaonBack.common.exception.NotFoundException;
 import coLaon.ClaonBack.common.exception.ServiceUnavailableException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -68,5 +69,12 @@ public class GlobalExceptionHandler {
     public ExceptionDto handleUniqueConstraintException(Exception exception) {
         GlobalExceptionHandler.log.error("error message", exception);
         return new ConflictExceptionDto("Violate unique constraint - " + exception.getMessage());
+    }
+
+    @ExceptionHandler(value = {NotFoundException.class})
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ExceptionDto handleNotFoundException(Exception exception) {
+        GlobalExceptionHandler.log.error("error message", exception);
+        return new ConflictExceptionDto("Requested data not found - " + exception.getMessage());
     }
 }

--- a/src/main/java/coLaon/ClaonBack/common/exception/NotFoundException.java
+++ b/src/main/java/coLaon/ClaonBack/common/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package coLaon.ClaonBack.common.exception;
+
+public class NotFoundException extends BaseRuntimeException {
+    public NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/post/domain/Post.java
+++ b/src/main/java/coLaon/ClaonBack/post/domain/Post.java
@@ -36,17 +36,17 @@ public class Post extends BaseEntity {
     private User writer;
     @BatchSize(size = 10)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    private List<PostContents> contentsSet;
+    private List<PostContents> contentsList;
 
     @BatchSize(size = 10)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<ClimbingHistory> climbingHistorySet;
 
     public String getThumbnailUrl() {
-        if (this.getContentsSet().size() == 0) {
+        if (this.getContentsList().size() == 0) {
             return null;
         }
-        return this.getContentsSet().get(0).getUrl();
+        return this.getContentsList().get(0).getUrl();
     }
 
     private Post(
@@ -71,7 +71,7 @@ public class Post extends BaseEntity {
         this.content = content;
         this.isDeleted = false;
         this.writer = writer;
-        this.contentsSet = contentsSet;
+        this.contentsList = contentsSet;
         this.climbingHistorySet = climbingHistorySet;
     }
 
@@ -88,7 +88,7 @@ public class Post extends BaseEntity {
         this.content = content;
         this.isDeleted = false;
         this.writer = writer;
-        this.contentsSet = contentsSet;
+        this.contentsList = contentsSet;
         this.climbingHistorySet = climbingHistorySet;
     }
 
@@ -107,7 +107,7 @@ public class Post extends BaseEntity {
         this.content = content;
         this.isDeleted = false;
         this.writer = writer;
-        this.contentsSet = contentsSet;
+        this.contentsList = contentsSet;
         this.climbingHistorySet = climbingHistorySet;
     }
 

--- a/src/main/java/coLaon/ClaonBack/post/domain/Post.java
+++ b/src/main/java/coLaon/ClaonBack/post/domain/Post.java
@@ -5,6 +5,7 @@ import coLaon.ClaonBack.common.domain.BaseEntity;
 import coLaon.ClaonBack.user.domain.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -15,6 +16,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -32,10 +34,20 @@ public class Post extends BaseEntity {
     @ManyToOne(targetEntity = User.class)
     @JoinColumn(name = "user_id", nullable = false)
     private User writer;
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    private Set<PostContents> contentsSet;
+    private List<PostContents> contentsSet;
+
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<ClimbingHistory> climbingHistorySet;
+
+    public String getThumbnailUrl() {
+        if (this.getContentsSet().size() == 0) {
+            return null;
+        }
+        return this.getContentsSet().get(0).getUrl();
+    }
 
     private Post(
             Center center,
@@ -52,7 +64,7 @@ public class Post extends BaseEntity {
             Center center,
             String content,
             User writer,
-            Set<PostContents> contentsSet,
+            List<PostContents> contentsSet,
             Set<ClimbingHistory> climbingHistorySet
     ) {
         this.center = center;
@@ -68,7 +80,7 @@ public class Post extends BaseEntity {
             Center center,
             String content,
             User writer,
-            Set<PostContents> contentsSet,
+            List<PostContents> contentsSet,
             Set<ClimbingHistory> climbingHistorySet
     ) {
         super(id);
@@ -85,7 +97,7 @@ public class Post extends BaseEntity {
             Center center,
             String content,
             User writer,
-            Set<PostContents> contentsSet,
+            List<PostContents> contentsSet,
             Set<ClimbingHistory> climbingHistorySet,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
@@ -116,7 +128,7 @@ public class Post extends BaseEntity {
             Center center,
             String content,
             User writer,
-            Set<PostContents> contentsSet,
+            List<PostContents> contentsSet,
             Set<ClimbingHistory> climbingHistorySet
     ) {
         return new Post(
@@ -134,7 +146,7 @@ public class Post extends BaseEntity {
             Center center,
             String content,
             User writer,
-            Set<PostContents> contentsSet,
+            List<PostContents> contentsSet,
             Set<ClimbingHistory> climbingHistorySet,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
@@ -155,7 +167,7 @@ public class Post extends BaseEntity {
             Center center,
             String content,
             User writer,
-            Set<PostContents> contentsSet,
+            List<PostContents> contentsSet,
             Set<ClimbingHistory> climbingHistorySet
     ) {
         return new Post(

--- a/src/main/java/coLaon/ClaonBack/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/coLaon/ClaonBack/post/dto/PostDetailResponseDto.java
@@ -60,7 +60,7 @@ public class PostDetailResponseDto {
                         HoldInfoResponseDto.from(climbingHistory.getHoldInfo())).collect(Collectors.toList()),
                 post.getContent(),
                 RelativeTimeUtil.convertNow(OffsetDateTime.of(post.getCreatedAt(), ZoneOffset.of("+9"))),
-                post.getContentsSet().stream().map(PostContents::getUrl).collect(Collectors.toList())
+                post.getContentsList().stream().map(PostContents::getUrl).collect(Collectors.toList())
         );
     }
 }

--- a/src/main/java/coLaon/ClaonBack/post/dto/PostResponseDto.java
+++ b/src/main/java/coLaon/ClaonBack/post/dto/PostResponseDto.java
@@ -63,7 +63,7 @@ public class PostResponseDto {
                 post.getContent(),
                 RelativeTimeUtil.convertNow(OffsetDateTime.of(post.getCreatedAt(), ZoneOffset.of("+9"))),
                 post.getIsDeleted(),
-                post.getContentsSet().stream().map(PostContents::getUrl).collect(Collectors.toList())
+                post.getContentsList().stream().map(PostContents::getUrl).collect(Collectors.toList())
         );
     }
 

--- a/src/main/java/coLaon/ClaonBack/post/dto/PostThumbnailResponseDto.java
+++ b/src/main/java/coLaon/ClaonBack/post/dto/PostThumbnailResponseDto.java
@@ -1,0 +1,27 @@
+package coLaon.ClaonBack.post.dto;
+
+import coLaon.ClaonBack.post.domain.Post;
+import lombok.Data;
+
+@Data
+public class PostThumbnailResponseDto {
+    private final String postId;
+    private final String thumbnailUrl;
+
+    private PostThumbnailResponseDto(
+            String postId,
+            String thumbnailUrl
+    ) {
+        this.postId = postId;
+        this.thumbnailUrl = thumbnailUrl;
+
+    }
+
+    public static PostThumbnailResponseDto from(Post post) {
+        return new PostThumbnailResponseDto(
+                post.getId(),
+                post.getThumbnailUrl()
+        );
+    }
+
+}

--- a/src/main/java/coLaon/ClaonBack/post/repository/PostRepository.java
+++ b/src/main/java/coLaon/ClaonBack/post/repository/PostRepository.java
@@ -1,7 +1,9 @@
 package coLaon.ClaonBack.post.repository;
 
-import coLaon.ClaonBack.center.domain.Center;
 import coLaon.ClaonBack.post.domain.Post;
+import coLaon.ClaonBack.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -36,4 +38,5 @@ public interface PostRepository extends JpaRepository<Post, String> {
             "ON p.user_id = bu.user_id " +
             "WHERE bu.block_user_id = :userId) a" , nativeQuery = true)
     Integer selectCountByCenter(@Param("centerId")String centerId, @Param("userId")String userId);
+    Page<Post> findByWriterOrderByCreatedAtDesc(User writer, Pageable pageable);
 }

--- a/src/main/java/coLaon/ClaonBack/post/service/PostService.java
+++ b/src/main/java/coLaon/ClaonBack/post/service/PostService.java
@@ -7,6 +7,7 @@ import coLaon.ClaonBack.common.domain.Pagination;
 import coLaon.ClaonBack.common.domain.PaginationFactory;
 import coLaon.ClaonBack.common.exception.BadRequestException;
 import coLaon.ClaonBack.common.exception.ErrorCode;
+import coLaon.ClaonBack.common.exception.NotFoundException;
 import coLaon.ClaonBack.common.exception.UnauthorizedException;
 import coLaon.ClaonBack.common.validator.ContentsImageFormatValidator;
 import coLaon.ClaonBack.common.validator.IdEqualValidator;
@@ -20,6 +21,7 @@ import coLaon.ClaonBack.post.dto.LikeResponseDto;
 import coLaon.ClaonBack.post.dto.PostCreateRequestDto;
 import coLaon.ClaonBack.post.dto.PostDetailResponseDto;
 import coLaon.ClaonBack.post.dto.PostResponseDto;
+import coLaon.ClaonBack.post.dto.PostThumbnailResponseDto;
 import coLaon.ClaonBack.post.repository.ClimbingHistoryRepository;
 import coLaon.ClaonBack.post.repository.PostContentsRepository;
 import coLaon.ClaonBack.post.repository.PostLikeRepository;
@@ -28,6 +30,7 @@ import coLaon.ClaonBack.user.domain.User;
 import coLaon.ClaonBack.user.repository.BlockUserRepository;
 import coLaon.ClaonBack.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,13 +42,13 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PostService {
     private final UserRepository userRepository;
+    private final BlockUserRepository blockUserRepository;
     private final PostRepository postRepository;
     private final PostContentsRepository postContentsRepository;
     private final PostLikeRepository postLikeRepository;
     private final HoldInfoRepository holdInfoRepository;
     private final CenterRepository centerRepository;
     private final ClimbingHistoryRepository climbingHistoryRepository;
-    private final BlockUserRepository blockUserRepository;
     private final PaginationFactory paginationFactory;
 
     @Transactional(readOnly = true)
@@ -248,5 +251,32 @@ public class PostService {
                 postLikeRepository.findAllByPost(post, pageable)
                         .map(LikeFindResponseDto::from)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostThumbnailResponseDto> getUserPosts(String loginedUserId, String targetUserNickname, Pageable pageable){
+        User targetUser = userRepository.findByNickname(targetUserNickname).orElseThrow(
+                () -> new NotFoundException(
+                        ErrorCode.USER_DOES_NOT_EXIST,
+                        "요청한 사용자가 존재하지 않습니다. "
+                )
+        );
+
+        // my page
+        if (loginedUserId.equals(targetUser.getId())) {
+            postRepository.findByWriterOrderByCreatedAtDesc(targetUser, pageable).map(PostThumbnailResponseDto::from);
+        }
+
+        if (targetUser.getIsPrivate()){
+            throw new UnauthorizedException(ErrorCode.NOT_ACCESSIBLE, "해당 사용자는 비공개 입니다. ");
+        }
+
+        blockUserRepository.findByUserIdAndBlockId(targetUser.getId(), loginedUserId).ifPresent(
+                (blockUser -> {
+                    throw new UnauthorizedException(ErrorCode.NOT_ACCESSIBLE, "조회가 불가능한 사용자입니다. ");
+                })
+        );
+
+        return postRepository.findByWriterOrderByCreatedAtDesc(targetUser, pageable).map(PostThumbnailResponseDto::from);
     }
 }

--- a/src/main/java/coLaon/ClaonBack/post/web/PostController.java
+++ b/src/main/java/coLaon/ClaonBack/post/web/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
 
     @GetMapping
     @ResponseStatus(value = HttpStatus.OK)
-    public Page<PostThumbnailResponseDto> getIndividualUserPost(@AuthenticationPrincipal String userId, @RequestParam(name="nickname") String targetUserNickname, @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public Pagination<PostThumbnailResponseDto> getIndividualUserPost(@AuthenticationPrincipal String userId, @RequestParam(name="nickname") String targetUserNickname, @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return postService.getUserPosts(userId, targetUserNickname, pageable);
     }
 

--- a/src/main/java/coLaon/ClaonBack/post/web/PostController.java
+++ b/src/main/java/coLaon/ClaonBack/post/web/PostController.java
@@ -1,9 +1,6 @@
 package coLaon.ClaonBack.post.web;
 
 import coLaon.ClaonBack.common.domain.Pagination;
-import coLaon.ClaonBack.post.dto.PostDetailResponseDto;
-import coLaon.ClaonBack.post.service.PostCommentService;
-import coLaon.ClaonBack.post.service.PostService;
 import coLaon.ClaonBack.post.dto.CommentUpdateRequestDto;
 import coLaon.ClaonBack.post.dto.LikeFindResponseDto;
 import coLaon.ClaonBack.post.dto.LikeResponseDto;
@@ -13,14 +10,18 @@ import coLaon.ClaonBack.post.dto.CommentFindResponseDto;
 import coLaon.ClaonBack.post.dto.ChildCommentResponseDto;
 import coLaon.ClaonBack.post.dto.PostResponseDto;
 import coLaon.ClaonBack.post.dto.PostCreateRequestDto;
+import coLaon.ClaonBack.post.dto.PostThumbnailResponseDto;
+import coLaon.ClaonBack.post.dto.PostDetailResponseDto;
+import coLaon.ClaonBack.post.service.PostCommentService;
+import coLaon.ClaonBack.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -29,6 +30,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import javax.validation.Valid;
 
@@ -38,6 +41,12 @@ import javax.validation.Valid;
 public class PostController {
     private final PostService postService;
     private final PostCommentService postCommentService;
+
+    @GetMapping
+    @ResponseStatus(value = HttpStatus.OK)
+    public Page<PostThumbnailResponseDto> getIndividualUserPost(@AuthenticationPrincipal String userId, @RequestParam(name="nickname") String targetUserNickname, @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return postService.getUserPosts(userId, targetUserNickname, pageable);
+    }
 
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)

--- a/src/main/java/coLaon/ClaonBack/user/repository/BlockUserRepository.java
+++ b/src/main/java/coLaon/ClaonBack/user/repository/BlockUserRepository.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 public interface BlockUserRepository extends JpaRepository<BlockUser, String> {
     @Query(value = "SELECT * " +
             "FROM TB_BLOCK_USER AS b " +
-            "WHERE b.user_id = :userId AND b.block_user_id = :blockId", nativeQuery = true)
-    Optional<BlockUser> findByUserIdAndBlockId(@Param("userId") String userId, @Param("blockId") String blockId);
+            "WHERE b.user_id = :userId AND b.block_user_id = :blockUserId", nativeQuery = true)
+    Optional<BlockUser> findByUserIdAndBlockId(@Param("userId") String userId, @Param("blockUserId") String blockUserId);
 
     @Query(value = "SELECT * " +
             "FROM TB_BLOCK_USER AS b " +

--- a/src/test/java/coLaon/ClaonBack/repository/ClimbingHistoryRepositoryTest.java
+++ b/src/test/java/coLaon/ClaonBack/repository/ClimbingHistoryRepositoryTest.java
@@ -81,7 +81,7 @@ public class ClimbingHistoryRepositoryTest {
                 center,
                 "testContent1",
                 user,
-                Set.of(),
+                List.of(),
                 Set.of()
         );
 

--- a/src/test/java/coLaon/ClaonBack/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/coLaon/ClaonBack/repository/PostLikeRepositoryTest.java
@@ -74,7 +74,7 @@ public class PostLikeRepositoryTest {
                 center,
                 "testContent1",
                 user,
-                Set.of(),
+                List.of(),
                 Set.of()
         ));
     }

--- a/src/test/java/coLaon/ClaonBack/service/PostLikeServiceTest.java
+++ b/src/test/java/coLaon/ClaonBack/service/PostLikeServiceTest.java
@@ -127,7 +127,7 @@ public class PostLikeServiceTest {
                 center,
                 "testContent1",
                 user,
-                Set.of(),
+                List.of(),
                 Set.of(),
                 LocalDateTime.now(),
                 LocalDateTime.now()
@@ -170,7 +170,7 @@ public class PostLikeServiceTest {
                 center,
                 "testContent2",
                 user2,
-                Set.of(postContents2),
+                List.of(postContents2),
                 Set.of(climbingHistory2),
                 LocalDateTime.now(),
                 LocalDateTime.now()

--- a/src/test/java/coLaon/ClaonBack/service/PostServiceTest.java
+++ b/src/test/java/coLaon/ClaonBack/service/PostServiceTest.java
@@ -435,13 +435,13 @@ public class PostServiceTest {
         Pageable pageable = PageRequest.of(0, 2);
         given(this.userRepository.findByNickname(this.user2.getNickname())).willReturn(Optional.of(this.user2));
         given(this.blockUserRepository.findByUserIdAndBlockId(this.user2.getId(), loginedUserId)).willReturn(Optional.empty());
-        given(this.postRepository.findByWriterOrderByCreatedAtDesc(this.user2, pageable)).willReturn(new PageImpl<>(List.of(samplePost)));
+        given(this.postRepository.findByWriterOrderByCreatedAtDesc(this.user2, pageable)).willReturn(new PageImpl<>(List.of(samplePost), pageable, 1));
 
         // when
         Pagination<PostThumbnailResponseDto> dtos = this.postService.getUserPosts(loginedUserId, this.user2.getNickname(), pageable);
 
         // then
-        assertThat(dtos.getTotalCount()).isEqualTo(1L);
+        assertThat(dtos.getResults().size()).isEqualTo(1);
     }
 
     @Test
@@ -453,7 +453,7 @@ public class PostServiceTest {
         given(this.userRepository.findByNickname(this.privateUser.getNickname())).willReturn(Optional.of(this.privateUser));
 
         // when & then
-        assertThrows(UnauthorizedException.class, () -> {
+        assertThrows(BadRequestException.class, () -> {
             this.postService.getUserPosts(loginedUserId, this.privateUser.getNickname(), pageable);
         });
     }

--- a/src/test/java/coLaon/ClaonBack/service/PostServiceTest.java
+++ b/src/test/java/coLaon/ClaonBack/service/PostServiceTest.java
@@ -77,6 +77,9 @@ public class PostServiceTest {
     @InjectMocks
     PostService postService;
 
+    @Spy
+    PaginationFactory paginationFactory = new PaginationFactory();
+
     private User user, user2, blockedUser, privateUser;
     private Post post, post2, blockedPost, privatePost;
     private PostContents postContents, postContents2;

--- a/src/test/java/coLaon/ClaonBack/service/UserServiceTest.java
+++ b/src/test/java/coLaon/ClaonBack/service/UserServiceTest.java
@@ -163,7 +163,7 @@ public class UserServiceTest {
                 center,
                 "testContent1",
                 user,
-                Set.of(),
+                List.of(),
                 Set.of(),
                 LocalDateTime.now(),
                 LocalDateTime.now()


### PR DESCRIPTION
## Related issue
resolves #151

## Description
개인 페이지 및 타 사용자 페이지 에서 사용되는 게시글 미리 보기 API를 개발하였습니다. 

## Changes detail
- `api/v1/posts?nickname=""`
- #151 에서는 별도의 API로 이야기가 나왔으나, 프론트에서 요청 재사용을 위해서 API를 통일하였습니다. (로직 상 분기) 

### Checklist

- [x] Test case
- [x] End of work
