### PR TITLE
refac: refactor s3 image upload method for resizing image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,11 @@ dependencies {
 	implementation 'commons-io:commons-io:2.11.0'
 	implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.4'
 
+	// image resize
+	implementation 'com.github.downgoon:marvin:1.5.5'
+	implementation 'com.github.downgoon:MarvinPlugins:1.5.5'
+	implementation 'org.springframework:spring-test'
+
 	// test
 	implementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 	implementation 'org.mockito:mockito-junit-jupiter:4.6.1'

--- a/src/main/java/coLaon/ClaonBack/common/utils/ImageUtil.java
+++ b/src/main/java/coLaon/ClaonBack/common/utils/ImageUtil.java
@@ -1,0 +1,73 @@
+package coLaon.ClaonBack.common.utils;
+
+import coLaon.ClaonBack.common.exception.ErrorCode;
+import coLaon.ClaonBack.common.exception.InternalServerErrorException;
+import lombok.RequiredArgsConstructor;
+import marvin.image.MarvinImage;
+import org.marvinproject.image.transform.scale.Scale;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class ImageUtil {
+    private final int RESIZED_LENGTH = 1920;
+
+    public MultipartFile resizeImage(MultipartFile file, String fileFormatName, String fileName) {
+        try {
+            BufferedImage image = ImageIO.read(file.getInputStream());
+            int originalWidth = image.getWidth();
+            int originalHeight = image.getHeight();
+
+            if ((originalWidth < RESIZED_LENGTH && originalWidth > originalHeight) ||
+                    (originalHeight < RESIZED_LENGTH && originalHeight > originalWidth)) {
+                return file;
+            }
+
+            MarvinImage marvinImage = new MarvinImage(image, fileFormatName);
+            scaleImage(marvinImage, originalWidth, originalHeight);
+
+            BufferedImage bufferedImage = marvinImage.getBufferedImageNoAlpha();
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            ImageIO.write(bufferedImage, fileFormatName, byteArrayOutputStream);
+            byteArrayOutputStream.flush();
+
+            return new MockMultipartFile(fileName, byteArrayOutputStream.toByteArray());
+
+        } catch (IOException e) {
+            throw new InternalServerErrorException(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    "파일 리사이즈를 실패했습니다."
+            );
+        }
+    }
+
+    private void scaleImage(MarvinImage marvinImage, int width, int height) {
+        Scale scale = new Scale();
+        scale.load();
+
+        if (width >= height) {
+            scale.setAttribute("newWidth", RESIZED_LENGTH);
+            scale.setAttribute("newHeight", RESIZED_LENGTH * height / width);
+        }
+
+        else {
+            scale.setAttribute("newWidth", RESIZED_LENGTH * width / height);
+            scale.setAttribute("newHeight", RESIZED_LENGTH);
+        }
+
+        scale.process(
+                marvinImage.clone(),
+                marvinImage,
+                null,
+                null,
+                false
+        );
+    }
+}

--- a/src/main/java/coLaon/ClaonBack/common/utils/S3Util.java
+++ b/src/main/java/coLaon/ClaonBack/common/utils/S3Util.java
@@ -4,6 +4,7 @@ import coLaon.ClaonBack.common.exception.ErrorCode;
 import coLaon.ClaonBack.common.exception.InternalServerErrorException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,10 +12,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.LocalDate;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.UUID;
 
 @Slf4j
@@ -22,56 +23,39 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class S3Util {
     private final AmazonS3Client amazonS3Client;
+    private final ImageUtil imageUtil;
 
     @Value("${cloud.aws.s3.bucket}")
     public String bucket;
 
-    public String upload(MultipartFile multipartFile, String dirName) {
-        File uploadFile = convert(multipartFile).orElseThrow(
-                () -> new InternalServerErrorException(
-                        ErrorCode.INTERNAL_SERVER_ERROR,
-                        "파일 전환에 실패했습니다."
-                )
-        );
-        return upload(uploadFile, dirName);
+    public String upload(MultipartFile uploadFile, String dirName) {
+        String fileFormatName = Objects.requireNonNull(uploadFile.getContentType())
+                .substring(uploadFile.getContentType().lastIndexOf("/") + 1);
+        String fileName = dirName + "/" + LocalDate.now() + "/" + UUID.randomUUID() + "." + fileFormatName;
+        MultipartFile resizedFile = imageUtil.resizeImage(uploadFile, fileFormatName, fileName);
+        ObjectMetadata objectMetadata = getObjectMetadata(uploadFile, resizedFile);
+
+        return putS3(resizedFile, fileName, objectMetadata);
     }
 
-    private String upload(File uploadFile, String dirName) {
-        String fileName = dirName + "/" + LocalDate.now() + "/" + UUID.randomUUID() + "." +
-                uploadFile.getName().substring(uploadFile.getName().lastIndexOf(".") + 1);
-        String uploadImageUrl = putS3(uploadFile, fileName);
-        removeNewFile(uploadFile);
-        return uploadImageUrl;
-    }
-
-    private String putS3(File uploadFile, String fileName) {
-        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+    private String putS3(MultipartFile resizedFile, String fileName, ObjectMetadata objectMetadata) {
+        try (InputStream inputStream = resizedFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new InternalServerErrorException(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    "이미지 업로드를 실패했습니다."
+            );
+        }
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
-    private void removeNewFile(File targetFile) {
-        if (targetFile.delete()) {
-            log.info("File delete success");
-            return;
-        }
-        log.info("File delete fail");
-    }
+    private ObjectMetadata getObjectMetadata(MultipartFile file, MultipartFile resizedFile) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(resizedFile.getSize());
+        objectMetadata.setContentType(file.getContentType());
 
-    private Optional<File> convert(MultipartFile multipartFile) {
-        File convertFile = new File(
-                System.getProperty("user.dir") + "/" + multipartFile.getOriginalFilename()
-        );
-
-        try (FileOutputStream fos = new FileOutputStream(convertFile)) {
-            if (convertFile.createNewFile()) {
-                fos.write(multipartFile.getBytes());
-            } else {
-                return Optional.empty();
-            }
-        } catch (Exception e) {
-            return Optional.empty();
-        }
-
-        return Optional.of(convertFile);
+        return objectMetadata;
     }
 }

--- a/src/main/java/coLaon/ClaonBack/common/validator/IsImageValidator.java
+++ b/src/main/java/coLaon/ClaonBack/common/validator/IsImageValidator.java
@@ -23,7 +23,7 @@ public class IsImageValidator extends Validator {
     @Override
     public void validate() {
         try {
-            if (Files.probeContentType(Path.of(Objects.requireNonNull(multipartFile.getOriginalFilename())))
+            if (!Files.probeContentType(Path.of(Objects.requireNonNull(multipartFile.getOriginalFilename())))
                     .startsWith("image")) {
                 throw new BadRequestException(
                         ErrorCode.INVALID_FORMAT,


### PR DESCRIPTION
## Related issue
resolves #172 

## Description
refac: refactor s3 image upload method for resizing image
fix: modify IsImageValidator because of wrong condition

<img width="960" alt="Screen Shot 2022-08-13 at 12 16 12 AM" src="https://user-images.githubusercontent.com/98951922/184386339-0f52627d-f7b9-402f-b4c7-37c816530878.png">
[original image]

<img width="843" alt="Screen Shot 2022-08-13 at 12 13 40 AM" src="https://user-images.githubusercontent.com/98951922/184386426-9891ab17-0c2e-41e1-97f9-ad296283284b.png">
[resized image in s3]


### Checklist

- [ ] Test case
- [ ] End of work
