### PR TITLE
ci: move build to test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: build with Gradle
-        run: ./gradlew build
+      - name: Test with Gradle
+        run: ./gradlew --info test


### PR DESCRIPTION
## Related issue
resolves #issue_number

## Description
기존 gradle Build workflow는 어떤 테스트 케이스가 실패했는지 파이프라인 상 알 수 없습니다. 따라서 gradle info test 커멘드로 대체합니다. 

## Changes detail
- 

### Checklist

- [ ] Test case
- [ ] End of work
