### PR TITLE
fix: fix bug when access token is invalid and refresh token is valid

### DIFF
--- a/src/main/java/coLaon/ClaonBack/common/utils/JwtUtil.java
+++ b/src/main/java/coLaon/ClaonBack/common/utils/JwtUtil.java
@@ -95,4 +95,14 @@ public class JwtUtil {
             return false;
         }
     }
+
+    public boolean isExpiredToken(String jwtToken) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(this.SECRET_KEY).parseClaimsJws(jwtToken);
+
+            return claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## Related issue
resolves None

## Description
fix bug when access token is invalid and refresh token is valid

## Changes detail

- fix bug when access token is invalid and refresh token is valid
- refactor doFilter function of JwtAuthenticationFilter

### Checklist

- [ ] Test case
- [x] End of work
